### PR TITLE
Allow single satoshi units for invoice creations

### DIFF
--- a/lib/bitpay/client.rb
+++ b/lib/bitpay/client.rb
@@ -66,7 +66,7 @@ module BitPay
         raise BitPay::ArgumentError, "Illegal Argument: Price must be formatted as a float" unless 
           price.is_a?(Numeric) ||
           /^[[:digit:]]+(\.[[:digit:]]{2})?$/.match(price) ||
-          currency == 'BTC' && /^[[:digit:]]+(\.[[:digit:]]{1,6})?$/.match(price)
+          currency == 'BTC' && /^[[:digit:]]+(\.[[:digit:]]{1,8})?$/.match(price)
         raise BitPay::ArgumentError, "Illegal Argument: Currency is invalid." unless /^[[:upper:]]{3}$/.match(currency)
         params.merge!({price: price, currency: currency})
         token = get_token(facade)

--- a/lib/bitpay/version.rb
+++ b/lib/bitpay/version.rb
@@ -3,5 +3,5 @@
 # or https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
 
 module BitPay
-  VERSION = '2.4.5'
+  VERSION = '2.4.6'
 end


### PR DESCRIPTION
Changed the verification parameters so that single satoshi units are possible for invoice creations. More important now, since lightning payments are possible through BTCPayServer.